### PR TITLE
Add shebang lines to make CLI tools runnable

### DIFF
--- a/bin/clock.js
+++ b/bin/clock.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 var FlipDot = require('../flipdot.js');
 var dateFormat = require('dateformat');
 var args = require('args')

--- a/bin/term.js
+++ b/bin/term.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 var FlipDot = require('../flipdot.js')
 var args = require('args')
 


### PR DESCRIPTION
Without these your shell will attempt to run the node code as shell script and fail. This allows you to run `flipdot` and `flipdot-clock` without having to specify that they should be run under node.