### PR TITLE
Remove unnecessary fill in terminal usage

### DIFF
--- a/bin/term.js
+++ b/bin/term.js
@@ -22,7 +22,6 @@ flippy.on("error", function(err) {
 });
 
 flippy.once("open", function() {
-  flippy.fill(0xFF);
   flippy.writeText(flags.string, {font: flags.font}, [flags.xaxis,flags.yaxis], flags.invert)
   console.log('Sending: ' + flags.string)
   flippy.send(() => {


### PR DESCRIPTION
A frame of all zeros is sent before desired image data
On my sign this results in no image information displayed